### PR TITLE
Add splitpane to reduxfx-view

### DIFF
--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/VScenegraphFactory.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/VScenegraphFactory.java
@@ -17,6 +17,7 @@ import com.netopyr.reduxfx.vscenegraph.builders.ProgressBarBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.ProgressIndicatorBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.ScrollPaneBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.SliderBuilder;
+import com.netopyr.reduxfx.vscenegraph.builders.SplitPaneBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.TextFieldBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.TextInputControlBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.TitledPaneBuilder;
@@ -211,6 +212,10 @@ public class VScenegraphFactory {
         return Factory.node(ContextMenu.class, () -> new ContextMenuBuilder<>(ContextMenu.class, HashMap.empty(), HashMap.empty(), HashMap.empty(), HashMap.empty()));
     }
 
+
+    public static <CLASS extends SplitPaneBuilder<CLASS>> SplitPaneBuilder<CLASS> SplitPane() {
+        return Factory.node(SplitPane.class, () -> new SplitPaneBuilder<CLASS>(SplitPane.class, HashMap.empty(), HashMap.empty(), HashMap.empty(), HashMap.empty()));
+    }
 
 
 //    @SafeVarargs

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/SplitPaneBuilder.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/SplitPaneBuilder.java
@@ -1,0 +1,60 @@
+package com.netopyr.reduxfx.vscenegraph.builders;
+
+import com.netopyr.reduxfx.vscenegraph.VNode;
+import com.netopyr.reduxfx.vscenegraph.event.VEventHandler;
+import com.netopyr.reduxfx.vscenegraph.event.VEventType;
+import com.netopyr.reduxfx.vscenegraph.property.VProperty;
+import javafx.geometry.Orientation;
+import javaslang.collection.Array;
+import javaslang.collection.Map;
+import javaslang.control.Option;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class SplitPaneBuilder<BUILDER extends SplitPaneBuilder<BUILDER>> extends ControlBuilder<BUILDER> {
+
+	private static final String ORIENTATION = "orientation";
+	private static final String ITEMS = "items";
+	private static final String DIVIDER_POSITIONS = "dividerPositions";
+
+	public SplitPaneBuilder(Class<?> nodeClass,
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		super(nodeClass, childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected BUILDER create(
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		return (BUILDER) new SplitPaneBuilder<>(getNodeClass(), childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	public BUILDER orientation(Orientation orientation) {
+		return property(ORIENTATION, orientation);
+	}
+
+	public BUILDER items(VNode... nodes) {
+		return children(ITEMS, nodes == null ? Array.empty() : Array.of(nodes));
+	}
+
+	public BUILDER items(Iterable<VNode> nodes) {
+		return children(ITEMS, nodes == null ? Array.empty() : Array.ofAll(nodes));
+	}
+
+	public BUILDER dividerPositions(double... positions) {
+		return property(DIVIDER_POSITIONS, positions);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.appendSuper(super.toString())
+			.toString();
+	}
+}

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/property/SetterAccessor.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/property/SetterAccessor.java
@@ -17,7 +17,19 @@ public class SetterAccessor implements Accessor {
     public void set(Consumer<Object> dispatcher, Object node, String name, VProperty vProperty) {
         if (vProperty.isValueDefined()) {
             try {
-                setter.invoke(node, vProperty.getValue());
+                final Object value = vProperty.getValue();
+
+                if (value instanceof int[]) {
+                    setter.invoke(node, (int[]) value);
+                } else if (value instanceof double[]) {
+                    setter.invoke(node, (double[]) value);
+                } else if (value instanceof long[]) {
+                    setter.invoke(node, (long[]) value);
+                } else if (value instanceof float[]) {
+                    setter.invoke(node, (float[]) value);
+                } else {
+                    setter.invoke(node, value);
+                }
             } catch (Throwable throwable) {
                 throw new IllegalStateException("Unable to set property " + name + " from Node-class " + node.getClass(), throwable);
             }


### PR DESCRIPTION
I've added a builder for JavaFX SplitPane. 

I had a problem with the `setDividerPositions` method because it takes an array of double values. 
This caused a `ClassCastException` in `SetterAccessor`. After a short google research I think the reason is that there is some problem with var-args expansion of array arguments. 
I solved this by checking the type of the argument and explicitly casting it. Maybe there is a clearer solution to this?