### PR TITLE
fix IndexOutOfBoundException in Patcher on RemovePatch

### DIFF
--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/differ/Differ.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/differ/Differ.java
@@ -105,7 +105,7 @@ public class Differ {
                                 : result.merge(doDiff(currentPath.append(i), aChild, bChild), Vector::appendAll);
                     }
 
-                    for (int i = n; i < nA; i++) {
+                    for (int i = nA-1; i >= n; i--) {
                         result = result.merge(HashMap.of(Phase.STRUCTURE, Vector.of(new RemovePatch(currentPath, i))), Vector::appendAll);
                     }
 


### PR DESCRIPTION
I've found a possible IndexOutOfBoundException in `Patcher.java`.

Think of the following example: Before the an Action is applied a TreeView has 3 Children. 
After the Action, the TreeView is empty. The Differ calculates that 3 `RemovePatches` have to be applied to he VSceneGraph.

This is done in [Differ.java (Line 108-110)](https://github.com/netopyr/reduxfx/blob/master/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/differ/Differ.java#L108-L110). However, the problem here is the iteration. The for loop runs from 0 to 2 and adds the RemovePatches in this order.
Now we have:

RemovePatch(index=0,...)
RemovePatch(index=1,...)
RemovePatch(index=2,...)

In [Patcher 148-155](https://github.com/netopyr/reduxfx/blob/master/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/Patcher.java#L148-L155) these patches are applied.
However, the third patch can't be applied because there is no element with index=2 left anymore. Instead an `IndexOutOfBoundException` is thrown.

To fix this the order of the patches has to be reversed. The patch with the highest index has to be applied first. To do this I've reversed the for-loop in Differ.java to count from 2 to 0 instead. 

I've tried out this fix with a small app and it solved the problem without noticing any negative side effects. However, I don't know if this breaks some other use-cases that I haven't thought about. 


