### PR TITLE
Tabpane

### DIFF
--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/VScenegraphFactory.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/VScenegraphFactory.java
@@ -24,6 +24,8 @@ import com.netopyr.reduxfx.vscenegraph.builders.TitledPaneBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.ToggleButtonBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.TreeItemBuilder;
 import com.netopyr.reduxfx.vscenegraph.builders.TreeViewBuilder;
+import com.netopyr.reduxfx.vscenegraph.builders.TabBuilder;
+import com.netopyr.reduxfx.vscenegraph.builders.TabPaneBuilder;
 import com.netopyr.reduxfx.vscenegraph.javafx.TreeItemWrapper;
 import javafx.scene.Group;
 import javafx.scene.Node;
@@ -225,6 +227,14 @@ public class VScenegraphFactory {
 
     public static <B extends SplitPaneBuilder<B>> SplitPaneBuilder<B> SplitPane() {
         return Factory.node(SplitPane.class, () -> new SplitPaneBuilder<B>(SplitPane.class, HashMap.empty(), HashMap.empty(), HashMap.empty(), HashMap.empty()));
+    }
+
+    public static <B extends TabBuilder<B>> TabBuilder<B> Tab() {
+        return Factory.node(Tab.class, () -> new TabBuilder<>(Tab.class, HashMap.empty(), HashMap.empty(), HashMap.empty(), HashMap.empty()));
+    }
+
+    public static <B extends TabPaneBuilder<B>> TabPaneBuilder<B> TabPane() {
+        return Factory.node(TabPane.class, () -> new TabPaneBuilder<>(TabPane.class, HashMap.empty(), HashMap.empty(), HashMap.empty(), HashMap.empty()));
     }
 
 }

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/ContextMenuBuilder.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/ContextMenuBuilder.java
@@ -34,7 +34,7 @@ public class ContextMenuBuilder<B extends ContextMenuBuilder<B>> extends PopupCo
     }
 
 
-    public B items(VNode... items) {
+    public B items(MenuItemBuilder... items) {
         return children(ITEMS, items == null? Array.empty() : Array.of(items));
     }
 

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/TabBuilder.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/TabBuilder.java
@@ -1,0 +1,94 @@
+package com.netopyr.reduxfx.vscenegraph.builders;
+
+import com.netopyr.reduxfx.vscenegraph.VNode;
+import com.netopyr.reduxfx.vscenegraph.event.VEventHandler;
+import com.netopyr.reduxfx.vscenegraph.event.VEventType;
+import com.netopyr.reduxfx.vscenegraph.impl.patcher.property.Accessors;
+import com.netopyr.reduxfx.vscenegraph.impl.patcher.property.StyleClassAccessor;
+import com.netopyr.reduxfx.vscenegraph.property.VProperty;
+import io.vavr.collection.Array;
+import io.vavr.collection.Map;
+import io.vavr.control.Option;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class TabBuilder<B extends TabBuilder<B>> extends Builder<B> {
+
+	private static final String CLOSABLE = "closable";
+	private static final String CONTENT = "content";
+	private static final String CONTEXT_MENU = "contextMenu";
+	private static final String GRAPHIC = "graphic";
+	private static final String TEXT = "text";
+
+//	TODO
+//	private static final String TOOLTIP = "tooltip";
+
+	private static final String ID = "id";
+	private static final String DISABLE = "disable";
+	private static final String STYLE = "style";
+	private static final String STYLE_CLASS = "styleClass";
+
+
+
+	public TabBuilder(Class<?> nodeClass,
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		super(nodeClass, childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected B create(
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		return (B) new TabBuilder<>(getNodeClass(), childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	public B content(VNode value) {
+		return child(CONTENT, value);
+	}
+
+	public B text(String value) {
+		return property(TEXT, value);
+	}
+
+	public B closable(boolean value) {
+		return property(CLOSABLE, value);
+	}
+
+	public B graphic(VNode value) {
+		return child(GRAPHIC, value);
+	}
+
+	public B contextMenu(ContextMenuBuilder value) {
+		return child(CONTEXT_MENU, value);
+	}
+
+	public B id(String value) {
+		return property(ID, value);
+	}
+
+	public B style(String value) {
+		return property(STYLE, value);
+	}
+
+	public B styleClass(String... value) {
+		Accessors.registerAccessor(getNodeClass(), STYLE_CLASS, StyleClassAccessor::new);
+		return property(STYLE_CLASS, value == null ? Array.empty() : Array.of(value));
+	}
+
+	public B disable(boolean value) {
+		return property(DISABLE, value);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.appendSuper(super.toString())
+			.toString();
+	}
+}

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/TabPaneBuilder.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/builders/TabPaneBuilder.java
@@ -1,0 +1,108 @@
+package com.netopyr.reduxfx.vscenegraph.builders;
+
+import com.netopyr.reduxfx.vscenegraph.VNode;
+import com.netopyr.reduxfx.vscenegraph.event.VEventHandler;
+import com.netopyr.reduxfx.vscenegraph.event.VEventType;
+import com.netopyr.reduxfx.vscenegraph.impl.patcher.property.Accessors;
+import com.netopyr.reduxfx.vscenegraph.impl.patcher.property.TabPaneSelectionModelAccessor;
+import com.netopyr.reduxfx.vscenegraph.property.VChangeListener;
+import com.netopyr.reduxfx.vscenegraph.property.VProperty;
+import io.vavr.collection.Array;
+import io.vavr.collection.Map;
+import io.vavr.control.Option;
+import javafx.geometry.Side;
+import javafx.scene.control.TabPane;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class TabPaneBuilder<B extends TabPaneBuilder<B>> extends ControlBuilder<B> {
+
+	private static final String TAB_MIN_HEIGHT = "tabMinHeight";
+	private static final String TAB_MIN_WIDTH = "tabMinWidth";
+	private static final String TAB_MAX_HEIGHT = "tabMaxHeight";
+	private static final String TAB_MAX_WIDTH = "tabMaxWidth";
+
+	private static final String TAB_CLOSING_POLICY = "tabClosingPolicy";
+	private static final String SIDE = "side";
+	private static final String ROTATED_GRAPHIC = "rotateGraphic";
+
+	private static final String SELECTION_MODEL = "selectionModel";
+
+	private static final String TABS = "tabs";
+
+
+	public TabPaneBuilder(Class<?> nodeClass,
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		super(nodeClass, childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected B create(
+		Map<String, Array<VNode>> childrenMap,
+		Map<String, Option<VNode>> singleChildMap,
+		Map<String, VProperty> properties,
+		Map<VEventType, VEventHandler> eventHandlers) {
+		return (B) new TabPaneBuilder<>(getNodeClass(), childrenMap, singleChildMap, properties, eventHandlers);
+	}
+
+	public B tabs(TabBuilder... values) {
+		return children(TABS, Array.of(values));
+	}
+
+	public B selectedIndex(int index) {
+		Accessors.registerAccessor(getNodeClass(), SELECTION_MODEL, TabPaneSelectionModelAccessor::new);
+
+		return property(SELECTION_MODEL, index);
+	}
+
+	public B selectedIndex(int index, VChangeListener<Integer> listener) {
+		Accessors.registerAccessor(getNodeClass(), SELECTION_MODEL, TabPaneSelectionModelAccessor::new);
+
+		return property(SELECTION_MODEL, index, listener);
+	}
+
+	public B selectedIndex(VChangeListener<Integer> listener) {
+		Accessors.registerAccessor(getNodeClass(), SELECTION_MODEL, TabPaneSelectionModelAccessor::new);
+
+		return property(SELECTION_MODEL, listener);
+	}
+
+	public B tabClosingPolicy(TabPane.TabClosingPolicy value) {
+		return property(TAB_CLOSING_POLICY, value);
+	}
+
+	public B side(Side value) {
+		return property(SIDE, value);
+	}
+
+	public B rotatedGraphic(boolean value) {
+		return property(ROTATED_GRAPHIC, value);
+	}
+
+	public B tabMaxHeight(double value) {
+		return property(TAB_MAX_HEIGHT, value);
+	}
+
+	public B tabMaxWidth(double value) {
+		return property(TAB_MAX_WIDTH, value);
+	}
+
+	public B tabMinHeight(double value) {
+		return property(TAB_MIN_HEIGHT, value);
+	}
+
+	public B tabMinWidth(double value) {
+		return property(TAB_MIN_WIDTH, value);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.appendSuper(super.toString())
+			.toString();
+	}
+}

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/NodeUtilities.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/NodeUtilities.java
@@ -6,6 +6,7 @@ import io.vavr.control.Option;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Dialog;
+import javafx.scene.control.Tab;
 import javafx.stage.Window;
 
 import java.lang.invoke.MethodHandle;
@@ -65,6 +66,10 @@ public class NodeUtilities {
 
                 Case($(instanceOf(TreeItemWrapper.class)),
                         TreeItemWrapper::getProperties
+                ),
+
+                Case($(instanceOf(Tab.class)),
+                    Tab::getProperties
                 ),
 
                 Case($(), new HashMap<>())

--- a/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/property/TabPaneSelectionModelAccessor.java
+++ b/reduxfx-view/src/main/java/com/netopyr/reduxfx/vscenegraph/impl/patcher/property/TabPaneSelectionModelAccessor.java
@@ -1,0 +1,45 @@
+package com.netopyr.reduxfx.vscenegraph.impl.patcher.property;
+
+import com.netopyr.reduxfx.vscenegraph.property.VProperty;
+import javafx.beans.property.ReadOnlyIntegerProperty;
+import javafx.scene.control.TabPane;
+
+import java.util.function.Consumer;
+
+public class TabPaneSelectionModelAccessor extends ListenerHandlingAccessor {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void set(Consumer<Object> dispatcher, Object node, String name, VProperty vProperty) {
+		if(! (node instanceof TabPane)) {
+			throw new IllegalStateException("Trying to set selectionModel of node " + node);
+		}
+
+		final TabPane tabPane = (TabPane) node;
+
+		final ReadOnlyIntegerProperty selectedIndexProperty = tabPane.getSelectionModel().selectedIndexProperty();
+
+		clearListeners(node, selectedIndexProperty);
+
+		final Object value = vProperty.isValueDefined() ? vProperty.getValue() : null;
+		tabPane.getSelectionModel().select((int) value);
+
+		if(vProperty.getChangeListener().isDefined()) {
+			setChangeListener(dispatcher, node, selectedIndexProperty, vProperty.getChangeListener().get());
+		}
+
+		if(vProperty.getInvalidationListener().isDefined()) {
+			setInvalidationListener(dispatcher, node, selectedIndexProperty, vProperty.getInvalidationListener().get());
+		}
+	}
+
+	@Override
+	protected Object fxToV(Object value) {
+		return value;
+	}
+
+	@Override
+	protected Object vToFX(Object value) {
+		return value;
+	}
+}


### PR DESCRIPTION
implemented Builders for TabPane and Tab.

During  testing the TabPane I've found that `ContextMenuBuilder` takes items of type `VNode` while the [original ContextMenu](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/ContextMenu.html#getItems--) takes items of type `MenuItem`.